### PR TITLE
utf_explicit_output_iterator_t

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,138 @@
+---
+AlignConsecutiveBitFields:
+  Enabled: true
+  AcrossEmptyLines: false
+  AcrossComments: false
+BreakAfterAttributes: Always
+BracedInitializerIndentWidth: 2
+BraceWrapping:
+  SplitEmptyNamespace: false
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: false
+  AfterStruct: true
+  AfterExternBlock: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  IndentBraces: true
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+BitFieldColonSpacing: Both
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Whitesmiths
+BreakBeforeConceptDeclarations: Always
+BreakBeforeInlineASMColon: Always
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: true
+ColumnLimit: 120
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+FixNamespaceComments: true
+IncludeBlocks: Preserve
+IndentAccessModifiers: false
+IndentCaseBlocks: true
+IndentCaseLabels: true
+IndentExternBlock: Indent
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth: 2
+IndentWrappedFunctionNames: true
+InsertBraces: false
+InsertNewlineAtEOF: true
+InsertTrailingCommas: None
+KeepEmptyLinesAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+Language: Cpp
+LineEnding: DeriveLF
+NamespaceIndentation: Inner
+PPIndentWidth: 0
+PackConstructorInitializers: CurrentLine
+PointerAlignment: Middle
+QualifierAlignment: Right
+ReferenceAlignment: Middle
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveParentheses: MultipleParentheses
+RemoveSemicolon: true
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Always
+ShortNamespaceLines: 1
+SortIncludes: Never
+SortUsingDeclarations: Lexicographic
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Both
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: Never
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: Never
+SpacesInParensOptions:
+  InCStyleCasts: false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: Latest
+TabWidth: 2
+UseTab: Never
+AlignConsecutiveAssignments:
+  Enabled: false
+  AcrossEmptyLines: false
+  AcrossComments: false
+AlignConsecutiveDeclarations:
+  Enabled: false
+AlignConsecutiveMacros:
+  Enabled: false
+AlignConsecutiveShortCaseStatements:
+  Enabled: true
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+AlignAfterOpenBracket: BlockIndent
+WhitespaceSensitiveMacros:
+  - PRAGMA_CLANG_WARNING_OFF
+  - PRAGMA_CLANG_WARNING_PUSH_OFF
+  - PRAGMA_GCC_WARNING_PUSH_OFF
+  - PRAGMA_GCC_WARNING_OFF

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+Checks: 'clang-diagnostic-*,clang-analyzer-*,cppcoreguidelines-*,modernize-*,bugprone-*,readability-identifier-naming,-modernize-use-trailing-return-type,misc-const-correctness'
+CheckOptions:
+  # General Naming Convention: lower_case
+  - key: readability-identifier-naming.NamespaceCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.ClassCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.StructCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.FunctionCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.VariableCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.PublicMemberCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: 'lower_case'
+  - key: readability-identifier-naming.ConstantCase
+    value: 'lower_case'
+  # Member variables should end with '_'
+  - key: readability-identifier-naming.MemberSuffix
+    value: '_'
+  # Macros should be UPPER_CASE
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: 'UPPER_CASE'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,41 +2,41 @@ name: CMake
 
 on:
   push:
-    branches: [ master ]
+    branches: [ "master" ]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
+      
   pull_request:
-    branches: [ master ]
-
-env:
-  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Release
-  CXX_COMPILER : clang-12
+    branches: [ "master" ]
+    paths-ignore:
+      - 'README.md'
+      - 'docs/**'
 
 jobs:
-  build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
-
+  build-and-test:
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
-    # install dependencies
-    - name: boost
-      run: sudo apt-get update && sudo apt-get install -yq libboost-dev libboost-test-dev
-      
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=${{env.CXX_COMPILER}} -DCMAKE_CXX_FLAGS="-fuse-ld=lld" -DLINK_FLAGS="-fuse-ld=lld"
+    - name: Add LLVM Repository
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 18
+        
+    - name: Install dependencies
+      run: |
+           sudo apt-get update
+           sudo apt-get install -y gcc-14 g++-14 cmake ninja-build clang-18 libfmt-dev libc++-18-dev libc++abi-18-dev
+           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
+           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    - name: tests clang-18-release
+      run: cmake --workflow --preset="clang-18-release"
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
+    - name: tests clang-18-libc++release
+      run: cmake --workflow --preset="clang-18-libc++release"
       
+    - name: tests gcc-14-release
+      run: cmake --workflow --preset="gcc-14-release"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,35 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+build*
+.cache*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 
 project(stralgo 
-        VERSION 1.2.1
+        VERSION 1.3.0
         LANGUAGES CXX
         HOMEPAGE_URL "https://github.com/arturbac/stralgo"
         )
@@ -36,7 +36,7 @@ CPMAddPackage(
 CPMAddPackage(
   small_vectors
   GITHUB_REPOSITORY arturbac/small_vectors
-  GIT_TAG        v3.1.1
+  GIT_TAG        v3.1.6
   )
   
 if( PROJECT_IS_TOP_LEVEL )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,9 +36,18 @@
       }
     },
     {
+      "name": "clang-18-release",
+      "inherits": [ "cfg-common", "cfg-ninja", "cfg-c++23" ],
+      "cacheVariables": { "CMAKE_CXX_COMPILER" : "clang++-18" }
+    },
+    {
+      "name": "clang-18-libc++release",
+      "inherits": ["clang-18-release", "cfg-libc++"]
+    },
+    {
       "name": "clang-17-release",
       "inherits": [ "cfg-common", "cfg-ninja", "cfg-c++23" ],
-      "cacheVariables": { "CMAKE_CXX_COMPILER" : "/usr/lib/llvm/17/bin/clang++" }
+      "cacheVariables": { "CMAKE_CXX_COMPILER" : "clang++-17" }
     },
     {
       "name": "clang-17-libc++release",
@@ -47,7 +56,7 @@
     {
       "name": "clang-16-release",
       "inherits": [ "cfg-common", "cfg-ninja", "cfg-c++23" ],
-      "cacheVariables": { "CMAKE_CXX_COMPILER" : "/usr/lib/llvm/16/bin/clang++" }
+      "cacheVariables": { "CMAKE_CXX_COMPILER" : "clang++-16" }
     },
     {
       "name": "clang-16-libc++release",
@@ -56,7 +65,7 @@
     {
       "name": "clang-15-release",
       "inherits": [ "cfg-common", "cfg-ninja", "cfg-c++23" ],
-      "cacheVariables": { "CMAKE_CXX_COMPILER": "/usr/lib/llvm/15/bin/clang++" }
+      "cacheVariables": { "CMAKE_CXX_COMPILER": "clang++-15" }
     },
     {
       "name": "clang-15-libc++release",
@@ -75,6 +84,14 @@
       "inherits": [ "cfg-common", "cfg-ninja", "cfg-c++23" ],
       "cacheVariables": {
         "CMAKE_CXX_COMPILER": "g++-13",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "gcc-14-release",
+      "inherits": [ "cfg-common", "cfg-ninja", "cfg-c++23" ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++-14",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
@@ -98,6 +115,14 @@
     }
   ],
   "buildPresets": [
+    {
+      "name": "clang-18-release",
+      "configurePreset": "clang-18-release"
+    },
+    {
+      "name": "clang-18-libc++release",
+      "configurePreset": "clang-18-libc++release"
+    },
     {
       "name": "clang-17-release",
       "configurePreset": "clang-17-release"
@@ -129,9 +154,25 @@
     {
       "name": "gcc-13-release",
       "configurePreset": "gcc-13-release"
+    },
+    {
+      "name": "gcc-14-release",
+      "configurePreset": "gcc-14-release"
     }
   ],
   "testPresets": [
+    {
+      "name": "clang-18-release",
+      "configurePreset": "clang-18-release",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": true}
+    },
+    {
+      "name": "clang-18-libc++release",
+      "configurePreset": "clang-18-libc++release",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": true}
+    },
     {
       "name": "clang-17-release",
       "configurePreset": "clang-17-release",
@@ -179,9 +220,49 @@
       "configurePreset": "gcc-13-release",
       "output": {"outputOnFailure": true},
       "execution": {"noTestsAction": "error", "stopOnFailure": true}
+    },
+    {
+      "name": "gcc-14-release",
+      "configurePreset": "gcc-14-release",
+      "output": {"outputOnFailure": true},
+      "execution": {"noTestsAction": "error", "stopOnFailure": true}
     }
   ],
   "workflowPresets": [
+    {
+      "name": "clang-18-release",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "clang-18-release"
+        },
+        {
+          "type": "build",
+          "name": "clang-18-release"
+        },
+        {
+          "type": "test",
+          "name": "clang-18-release"
+        }
+      ]
+    },
+    {
+      "name": "clang-18-libc++release",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "clang-18-libc++release"
+        },
+        {
+          "type": "build",
+          "name": "clang-18-libc++release"
+        },
+        {
+          "type": "test",
+          "name": "clang-18-libc++release"
+        }
+      ]
+    },
     {
       "name": "clang-17-release",
       "steps": [
@@ -298,6 +379,23 @@
         {
           "type": "test",
           "name": "gcc-12-release"
+        }
+      ]
+    },
+    {
+      "name": "gcc-14-release",
+      "steps": [
+        {
+          "type": "configure",
+          "name": "gcc-14-release"
+        },
+        {
+          "type": "build",
+          "name": "gcc-14-release"
+        },
+        {
+          "type": "test",
+          "name": "gcc-14-release"
         }
       ]
     },

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ Example using output iterator
 #### stralgo::utf convertion namespace
 
 * utf_input_view_t - utf view over range
+* deducing utf_forward_iterator_t
+* deducing utf_output_iterator_t with typed output iterators
+* utf_explicit_output_iterator_t for use with untyped outpt iterators (new in version 1.3.0)
 * length - number of code points in range
 * capacity_t<char_type> - number of bytes required to encode range into given char type, ie char8_t, char16_t, char32_t, wchar_t ...
 * convert - convert range into output iterator with other utf encoding

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,8 +1,11 @@
-set(CPM_DOWNLOAD_VERSION 0.36.0)
+# SPDX-License-Identifier: MIT
+#
+# SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
+
+set(CPM_DOWNLOAD_VERSION 0.40.0)
+set(CPM_HASH_SUM "7b354f3a5976c4626c876850c93944e52c83ec59a159ae5de5be7983f0e17a2a")
 
 if(CPM_SOURCE_CACHE)
-  # Expand relative path. This is important if the provided path contains a tilde (~)
-  get_filename_component(CPM_SOURCE_CACHE ${CPM_SOURCE_CACHE} ABSOLUTE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 elseif(DEFINED ENV{CPM_SOURCE_CACHE})
   set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
@@ -10,9 +13,12 @@ else()
   set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
 endif()
 
-if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
-  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
-  file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake ${CPM_DOWNLOAD_LOCATION})
-endif()
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+file(DOWNLOAD
+     https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM}
+)
 
 include(${CPM_DOWNLOAD_LOCATION})

--- a/include/stralgo/utf/detail/core.h
+++ b/include/stralgo/utf/detail/core.h
@@ -15,8 +15,8 @@ inline constexpr u32 surrogate_offset{0x10000u - (u32(lead_surrogate_min) << 10)
 struct utf8_code_point_size_t
   {
   [[nodiscard]]
-  stralgo_static_call_operator constexpr u8
-    operator()(std::same_as<char32_t> auto cp) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr u8 operator()(std::same_as<char32_t> auto cp
+  ) stralgo_static_call_operator_const noexcept
     {
     if(cp < 0x80u)
       return 1u;
@@ -34,8 +34,8 @@ inline constexpr utf8_code_point_size_t utf8_code_point_size;
 struct utf16_code_point_size_t
   {
   [[nodiscard]]
-  stralgo_static_call_operator constexpr u8
-    operator()(std::same_as<char32_t> auto cp) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr u8 operator()(std::same_as<char32_t> auto cp
+  ) stralgo_static_call_operator_const noexcept
     {
     return (cp < 0xffffu) ? 1 : 2;
     }
@@ -46,8 +46,8 @@ inline constexpr utf16_code_point_size_t utf16_code_point_size;
 struct utf32_code_point_size_t
   {
   [[nodiscard]]
-  stralgo_static_call_operator constexpr u8
-    operator()(std::same_as<char32_t> auto) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr u8 operator()(std::same_as<char32_t> auto
+  ) stralgo_static_call_operator_const noexcept
     {
     return 1;
     }
@@ -85,8 +85,8 @@ constexpr bool lead_surrogate(std::same_as<char16_t> auto cp) noexcept
 struct sequence_length_t
   {
   [[nodiscard]]
-  stralgo_static_call_operator constexpr u8
-    operator()(concepts::char_size<1> auto in_lead) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr u8 operator()(concepts::char_size<1> auto in_lead
+  ) stralgo_static_call_operator_const noexcept
     {
     auto lead = static_cast<u8>(in_lead);
     // u+0000  u+007f  	00xxxxxx
@@ -111,16 +111,16 @@ struct sequence_length_t
     }
 
   [[nodiscard]]
-  stralgo_static_call_operator constexpr u8
-    operator()(concepts::char_size<2> auto in_lead) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr u8 operator()(concepts::char_size<2> auto in_lead
+  ) stralgo_static_call_operator_const noexcept
     {
     auto cp{static_cast<char16_t>(in_lead)};
     return !lead_surrogate(cp) ? 1 : 2;
     }
 
   [[nodiscard]]
-  stralgo_static_call_operator constexpr u8
-    operator()(concepts::char_size<4> auto) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr u8 operator()(concepts::char_size<4> auto
+  ) stralgo_static_call_operator_const noexcept
     {
     return 1;
     }
@@ -136,8 +136,8 @@ inline constexpr u32 mask_6b{0b11'1111u};
 struct dereference_t
   {
   [[nodiscard]]
-  stralgo_static_call_operator constexpr char32_t
-    operator()(concepts::octet_iterator auto it) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr char32_t operator()(concepts::octet_iterator auto it
+  ) stralgo_static_call_operator_const noexcept
     {
     switch(sequence_length(*it))
       {
@@ -181,8 +181,8 @@ struct dereference_t
     }
 
   [[nodiscard]]
-  stralgo_static_call_operator constexpr char32_t
-    operator()(concepts::u16bit_iterator auto it) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr char32_t operator()(concepts::u16bit_iterator auto it
+  ) stralgo_static_call_operator_const noexcept
     {
     auto cp{static_cast<char16_t>(*it)};
     if(lead_surrogate(cp)) [[unlikely]]
@@ -196,8 +196,8 @@ struct dereference_t
     }
 
   [[nodiscard]]
-  stralgo_static_call_operator constexpr char32_t
-    operator()(concepts::u32bit_iterator auto it) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr char32_t operator()(concepts::u32bit_iterator auto it
+  ) stralgo_static_call_operator_const noexcept
     {
     return static_cast<char32_t>(*it);
     }
@@ -211,13 +211,13 @@ inline constexpr u32 lead_110{0b110'00000};
 inline constexpr u32 lead_1110{0b1110'0000};
 inline constexpr u32 lead_11110{0b11110'000};
 
-struct append_t
+template<stralgo::concepts::char_1b_type char_type>
+struct u8_append_t
   {
   stralgo_static_call_operator constexpr auto operator()(
-    std::same_as<char32_t> auto c, concepts::octet_iterator auto result
+    std::same_as<char32_t> auto c, std::output_iterator<char_type> auto result
   ) stralgo_static_call_operator_const noexcept
     {
-    using char_type = std::iter_value_t<decltype(result)>;
     auto cp{static_cast<u32>(c)};
     if(cp < 0x80)
       {
@@ -257,13 +257,15 @@ struct append_t
       }
     return result;
     }
+  };
 
-  [[nodiscard]]
-  stralgo_static_call_operator constexpr auto
-    operator()(std::same_as<char32_t> auto cp, concepts::u16bit_iterator auto result)
-      stralgo_static_call_operator_const noexcept
+template<stralgo::utf::concepts::char_size<2u> char_type>
+struct u16_append_t
+  {
+  stralgo_static_call_operator constexpr auto operator()(
+    std::same_as<char32_t> auto cp, std::output_iterator<char_type> auto result
+  ) stralgo_static_call_operator_const noexcept
     {
-    using char_type = std::iter_value_t<decltype(result)>;
     if(cp > 0xffffu)
       {
       *result = static_cast<char_type>((cp >> 10) + lead_offset);
@@ -278,20 +280,74 @@ struct append_t
       }
     return result;
     }
+  };
 
-  [[nodiscard]]
-  stralgo_static_call_operator constexpr auto
-    operator()(std::same_as<char32_t> auto cp, concepts::u32bit_iterator auto result)
-      stralgo_static_call_operator_const noexcept
+template<stralgo::utf::concepts::char_size<4u> char_type>
+struct u32_append_t
+  {
+  stralgo_static_call_operator constexpr auto operator()(
+    std::same_as<char32_t> auto cp, std::output_iterator<char_type> auto result
+  ) stralgo_static_call_operator_const noexcept
     {
-    using char_type = std::iter_value_t<decltype(result)>;
     *result = static_cast<char_type>(cp);
     ++result;
     return result;
     }
   };
 
+///\brief append which deduces output encoding by iterator value, requires typed output iterator
+struct append_t
+  {
+  stralgo_static_call_operator constexpr auto operator()(
+    std::same_as<char32_t> auto c, concepts::octet_iterator auto result
+  ) stralgo_static_call_operator_const noexcept
+    {
+    using char_type = std::iter_value_t<decltype(result)>;
+    return u8_append_t<char_type>{}(c, result);
+    }
+
+  [[nodiscard]]
+  stralgo_static_call_operator constexpr auto operator()(
+    std::same_as<char32_t> auto cp, concepts::u16bit_iterator auto result
+  ) stralgo_static_call_operator_const noexcept
+    {
+    using char_type = std::iter_value_t<decltype(result)>;
+    return u16_append_t<char_type>{}(cp, result);
+    }
+
+  [[nodiscard]]
+  stralgo_static_call_operator constexpr auto operator()(
+    std::same_as<char32_t> auto cp, concepts::u32bit_iterator auto result
+  ) stralgo_static_call_operator_const noexcept
+    {
+    using char_type = std::iter_value_t<decltype(result)>;
+    return u32_append_t<char_type>{}(cp, result);
+    }
+  };
+
 inline constexpr append_t append;
+
+///\brief append using explicit output encoding type for use with untyped output iterators
+template<stralgo::concepts::char_type char_type>
+struct explicit_append_t
+  {
+  stralgo_static_call_operator constexpr auto operator()(
+    std::same_as<char32_t> auto c, std::output_iterator<char_type> auto result
+  ) stralgo_static_call_operator_const noexcept
+    {
+    if constexpr( sizeof(char_type)== 1)
+      return u8_append_t<char_type>{}(c, result);
+    else if constexpr( sizeof(char_type)== 2)
+      return u16_append_t<char_type>{}(c, result);
+    else if constexpr( sizeof(char_type)== 4)
+      return u32_append_t<char_type>{}(c, result);
+    else 
+      throw;
+    }
+  };
+template<stralgo::concepts::char_type char_type>
+inline constexpr explicit_append_t<char_type> explicit_append;
+
 inline constexpr u32 mask_n6b{0b1100'0000};
 inline constexpr u32 mask_n10b{0b1111'1100'0000'0000u};
 
@@ -339,9 +395,8 @@ enum struct verify_status_e : uint8_t
 struct verify_code_point_t
   {
   template<concepts::octet_iterator octet_iterator, std::sentinel_for<octet_iterator> sentinel>
-  stralgo_static_call_operator constexpr auto
-    operator()(octet_iterator beg, sentinel end) stralgo_static_call_operator_const noexcept
-    -> std::pair<verify_status_e, octet_iterator>
+  stralgo_static_call_operator constexpr auto operator()(octet_iterator beg, sentinel end)
+    stralgo_static_call_operator_const noexcept -> std::pair<verify_status_e, octet_iterator>
     {
     using enum verify_status_e;
     u8 const code_point_length{sequence_length(*beg)};
@@ -371,3 +426,4 @@ struct verify_code_point_t
 
 inline constexpr verify_code_point_t verify_code_point;
   }  // namespace stralgo::utf::detail
+

--- a/include/stralgo/utf/utf.h
+++ b/include/stralgo/utf/utf.h
@@ -46,8 +46,7 @@ struct utf_forward_iterator_t
   constexpr explicit utf_forward_iterator_t(source_iterator src) : iter_{src} {}
 
   [[nodiscard]]
-  inline constexpr value_type
-    operator*() const noexcept
+  inline constexpr value_type operator*() const noexcept
     {
     return detail::dereference(iter_);
     }
@@ -59,8 +58,7 @@ struct utf_forward_iterator_t
     }
 
   [[nodiscard]]
-  inline constexpr utf_forward_iterator_t
-    operator++(int) noexcept
+  inline constexpr utf_forward_iterator_t operator++(int) noexcept
     {
     utf_forward_iterator_t copy{iter_};
     std::advance(iter_, detail::sequence_length(*iter_));
@@ -75,8 +73,7 @@ struct utf_forward_iterator_t
     }
 
   [[nodiscard]]
-  inline constexpr utf_forward_iterator_t
-    operator--(int) noexcept
+  inline constexpr utf_forward_iterator_t operator--(int) noexcept
     requires std::derived_from<iterator_category, std::bidirectional_iterator_tag>
     {
     utf_forward_iterator_t copy{iter_};
@@ -99,24 +96,21 @@ struct utf_forward_iterator_t
     }
 
   [[nodiscard]]
-  inline constexpr utf_forward_iterator_t
-    operator-(difference_type count) const noexcept
+  inline constexpr utf_forward_iterator_t operator-(difference_type count) const noexcept
     requires std::derived_from<iterator_category, std::random_access_iterator_tag>
     {
     return utf_forward_iterator_t{std::prev(iter_, count)};
     }
 
   [[nodiscard]]
-  inline constexpr utf_forward_iterator_t
-    operator+(difference_type count) const noexcept
+  inline constexpr utf_forward_iterator_t operator+(difference_type count) const noexcept
     requires std::derived_from<iterator_category, std::random_access_iterator_tag>
     {
     return utf_forward_iterator_t{std::next(iter_, count)};
     }
 
   [[nodiscard]]
-  inline constexpr char32_t &
-    operator[](std::size_t index) const noexcept
+  inline constexpr char32_t & operator[](std::size_t index) const noexcept
     {
     return *iter_[index];
     }
@@ -128,13 +122,11 @@ struct utf_forward_iterator_t
     }
 
   [[nodiscard]]
-  constexpr bool
-    operator==(utf_forward_iterator_t const & rh) const noexcept
+  constexpr bool operator==(utf_forward_iterator_t const & rh) const noexcept
     = default;
 
   [[nodiscard]]
-  constexpr auto
-    operator<=>(utf_forward_iterator_t const & rh) const noexcept
+  constexpr auto operator<=>(utf_forward_iterator_t const & rh) const noexcept
     = default;
   };
 
@@ -158,6 +150,7 @@ inline constexpr auto operator+(
   return utf_forward_iterator_t{std::next(it.iter_, count)};
   }
 
+///\brief output iterator deducing output encoding by output iterator value type, requires typed output iterator
 template<concepts::char_iterator TargetIter>
 struct utf_output_iterator_t
   {
@@ -183,11 +176,47 @@ struct utf_output_iterator_t
   inline constexpr utf_output_iterator_t & operator++() noexcept { return *this; }
 
   [[nodiscard]]
-  inline constexpr utf_output_iterator_t
-    operator++(int) noexcept
+  inline constexpr utf_output_iterator_t operator++(int) noexcept
     {
     return *this;
     }
+  };
+
+///\brief output iterator for use with untyped output iterators like std::back_inserter
+template<stralgo::concepts::char_type char_type>
+struct utf_explicit_output_iterator_t
+  {
+  template<std::output_iterator<char_type> TargetIter>
+  struct iterator
+    {
+    using value_type = char_type;
+    using difference_type = ptrdiff_t;
+    using target_iterator = TargetIter;
+    using iterator_category = std::output_iterator_tag;
+    target_iterator iter_;
+
+    constexpr iterator() noexcept = default;
+
+    inline constexpr explicit iterator(target_iterator src) noexcept : iter_{src} {}
+
+    inline constexpr iterator & operator=(std::same_as<char32_t> auto cp) noexcept
+      {
+      iter_ = detail::explicit_append<char_type>(cp, iter_);
+      return *this;
+      }
+
+    inline constexpr iterator & operator*() noexcept { return *this; }
+
+    inline constexpr iterator & operator++() noexcept { return *this; }
+
+    [[nodiscard]]
+    inline constexpr iterator operator++(int) noexcept
+      {
+      return *this;
+      }
+    };
+  template<std::output_iterator<char_type> TargetIter>
+  iterator(TargetIter src) -> iterator<TargetIter>;
   };
 
 // TODO write sentinel adapter for source sentinel
@@ -259,8 +288,8 @@ struct length_t
 
   template<concepts::char_range forward_range>
   [[nodiscard]]
-  stralgo_static_call_operator constexpr auto
-    operator()(forward_range const & range) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr auto operator()(forward_range const & range
+  ) stralgo_static_call_operator_const noexcept
     {
     return operator()(std::ranges::begin(range), std::ranges::end(range));
     }
@@ -300,8 +329,8 @@ struct capacity_t
 
   template<concepts::char_range forward_range>
   [[nodiscard]]
-  stralgo_static_call_operator constexpr auto
-    operator()(forward_range const & range) stralgo_static_call_operator_const noexcept
+  stralgo_static_call_operator constexpr auto operator()(forward_range const & range
+  ) stralgo_static_call_operator_const noexcept
     {
     return operator()(std::ranges::begin(range), std::ranges::end(range));
     }
@@ -347,7 +376,9 @@ namespace detail
     };
   }  // namespace detail
 
-template<concepts::char_type target_string_char, template<typename> typename basic_string_type = small_vectors::basic_string>
+template<
+  concepts::char_type target_string_char,
+  template<typename> typename basic_string_type = small_vectors::basic_string>
 struct to_string_t
   {
   using string_type = basic_string_type<target_string_char>;
@@ -382,8 +413,8 @@ struct to_string_t
 
   template<concepts::char_range forward_range>
   [[nodiscard]]
-  stralgo_static_call_operator constexpr auto
-    operator()(forward_range const & range) stralgo_static_call_operator_const->string_type
+  stralgo_static_call_operator constexpr auto operator()(forward_range const & range
+  ) stralgo_static_call_operator_const->string_type
     {
     return operator()(std::ranges::begin(range), std::ranges::end(range));
     }
@@ -447,8 +478,8 @@ struct verify_t
 
   template<concepts::char_range forward_range>
   [[nodiscard]]
-  stralgo_static_call_operator constexpr auto
-    operator()(forward_range const & range) noexcept stralgo_static_call_operator_const->verify_status_e
+  stralgo_static_call_operator constexpr auto operator()(forward_range const & range
+  ) noexcept stralgo_static_call_operator_const->verify_status_e
     {
     return operator()(std::ranges::begin(range), std::ranges::end(range));
     }

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,9 +1,9 @@
+add_subdirectory(ut_core)
+
 function( stralgo_add_unittest name )
   add_executable(${name}_ut)
   target_sources(${name}_ut PRIVATE ${name}.cc)
-  target_link_libraries( ${name}_ut PRIVATE stralgo )
-  target_link_libraries( ${name}_ut PRIVATE small_vectors_ut_core )
-  # add_dependencies(unit_tests ${name}_ut )
+  target_link_libraries( ${name}_ut PRIVATE stralgo_ut_core )
   add_test( NAME ${name}_test COMMAND ${name}_ut )
   target_compile_options( ${name}_ut PRIVATE ${STRALGO_COMPILE_OPTIONS} )
 endfunction()

--- a/unittests/ut_core/CMakeLists.txt
+++ b/unittests/ut_core/CMakeLists.txt
@@ -1,0 +1,43 @@
+#----------------------------------------------------------------
+# boost-ext/ut
+#----------------------------------------------------------------
+CPMAddPackage(
+  ut
+  GITHUB_REPOSITORY arturbac/ut-ext
+  GIT_TAG        master
+)
+
+add_library( stralgo_ut_core )
+target_sources( stralgo_ut_core PRIVATE unit_test_core.cc )
+target_link_libraries( stralgo_ut_core
+  PUBLIC
+    stralgo
+    Boost::ut
+    )
+target_include_directories( stralgo_ut_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} )
+target_compile_options(stralgo_ut_core
+  PUBLIC
+    ${SMALL_VECTORS_COMPILE_OPTIONS}
+    )
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  target_compile_options(stralgo_ut_core
+    PUBLIC
+      -Wno-disabled-macro-expansion
+      -Wno-used-but-marked-unused
+      -Wno-global-constructors
+      -Wno-exit-time-destructors
+      -Wno-ctad-maybe-unsupported
+      -Wno-weak-vtables
+      -fconstexpr-backtrace-limit=0
+      -Wno-misleading-indentation
+      -Wno-switch-default
+      )
+endif()
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(stralgo_ut_core
+    PUBLIC
+      -Wno-misleading-indentation
+      -Wno-attributes
+      -Wno-unused-parameter
+      )
+endif()

--- a/unittests/ut_core/boost_ut.h
+++ b/unittests/ut_core/boost_ut.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wsign-conversion"
+#pragma clang diagnostic ignored "-Wextra-semi"
+#pragma clang diagnostic ignored "-Wreserved-identifier"
+#endif
+
+#include <boost/ut.hpp>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/unittests/ut_core/unit_test_core.cc
+++ b/unittests/ut_core/unit_test_core.cc
@@ -1,0 +1,29 @@
+// #define BOOST_TEST_MAIN
+#include <unit_test_core.h>
+
+std::ostream & operator<<(std::ostream & stream, non_trivial_ptr const & v)
+  {
+  if(v.value_)
+    stream << *v.value_;
+  else
+    stream << "nullptr";
+  return stream;
+  }
+
+std::ostream & operator<<(std::ostream & stream, non_trivial_ptr_except const & v)
+  {
+  if(v.obj.value_)
+    stream << *v.obj.value_;
+  else
+    stream << "nullptr";
+  return stream;
+  }
+
+std::ostream & operator<<(std::ostream & stream, non_trivial_ptr_except_copy const & v)
+  {
+  if(v.obj.value_)
+    stream << *v.obj.value_;
+  else
+    stream << "nullptr";
+  return stream;
+  }

--- a/unittests/ut_core/unit_test_core.h
+++ b/unittests/ut_core/unit_test_core.h
@@ -1,0 +1,536 @@
+#pragma once
+
+#include <span>
+#include <numeric>
+#include <stdexcept>
+#include <utility>
+#include <cassert>
+#include <source_location>
+#include <iostream>
+
+#include <boost_ut.h>
+
+namespace metatests
+  {
+using boost::ut::reflection::source_location;
+
+struct test_result
+  {
+  enum struct value_type : uint8_t
+    {
+    succeed,
+    failed
+    };
+  using enum value_type;
+  value_type value_{};
+
+  explicit constexpr operator bool() const noexcept { return value_ == succeed; }
+
+  constexpr test_result() noexcept = default;
+
+  explicit constexpr test_result(bool value) noexcept : value_{value ? succeed : failed} {}
+
+  explicit constexpr test_result(value_type value) noexcept : value_{value} {}
+
+  constexpr test_result & operator|=(test_result rh) noexcept
+    {
+    value_ = value_ == failed || rh.value_ == failed ? failed : succeed;
+    return *this;
+    }
+
+  constexpr test_result operator|(test_result rh) noexcept
+    {
+    return test_result{value_ == failed || rh.value_ == failed ? failed : succeed};
+    }
+  };
+
+template<typename T, typename... U>
+concept is_any_of = (std::same_as<T, U> || ...);
+
+template<typename test_result_type>
+concept compatibile_test_result = is_any_of<test_result_type, bool, test_result>;
+
+template<compatibile_test_result test_result_type>
+constexpr test_result
+  constexpr_test(test_result_type expression, source_location const location = source_location::current())
+  {
+  if(std::is_constant_evaluated())
+    {
+    if(!expression)
+      throw;
+    return test_result{expression};
+    }
+  else
+    {
+    boost::ut::expect(static_cast<bool>(expression), location);
+    //     report_assertion(
+    //         ::boost::test_tools::assertion_result(expression),
+    //         BOOST_TEST_LAZY_MSG( str_expr ),
+    //         ::boost::unit_test::basic_cstring<char const>(file.data(), file.size()),
+    //         //BOOST_TEST_L(__FILE__),//
+    //         static_cast<std::size_t>(line),
+    //         ::boost::test_tools::tt_detail::CHECK,
+    //         ::boost::test_tools::tt_detail::CHECK_MSG,
+    //         0 );
+    return test_result{expression};
+    }
+  }
+
+template<typename except, typename test_type>
+test_result require_throw(test_type const & test) noexcept
+  {
+  try
+    {
+    test();
+    }
+  catch(except const &)
+    {
+    return test_result{};
+    }
+  catch(...)
+    {
+    return test_result{false};
+    }
+  return test_result{false};
+  }
+
+template<typename test_type>
+test_result require_throw(test_type const & test) noexcept
+  {
+  try
+    {
+    test();
+    }
+  catch(...)
+    {
+    return test_result{};
+    }
+  return test_result{false};
+  }
+
+template<typename unit_test>
+[[maybe_unused]]
+constexpr test_result
+  run_constexpr_test(unit_test const & test, source_location const location = source_location::current())
+  {
+  return constexpr_test(test(), location);
+  }
+
+template<typename unit_test>
+[[maybe_unused]]
+consteval test_result
+  run_consteval_test(unit_test const & test, source_location const location = source_location::current())
+  {
+  return constexpr_test(test(), location);
+  }
+
+namespace detail
+  {
+  template<typename T, typename... Args>
+  struct infer_type
+    {
+    using type = T;
+    using next_elem = infer_type<Args...>;
+    };
+
+  template<typename T>
+  struct infer_type<T>
+    {
+    using type = T;
+    using next_elem = void;
+    };
+  }  // namespace detail
+
+template<typename... Args>
+struct type_list
+  {
+  using type_iterator = detail::infer_type<Args...>;
+  };
+
+namespace detail
+  {
+  template<typename templ_list>
+  struct test_invoke
+    {
+    template<typename unit_test>
+    constexpr static test_result constexpr_run(unit_test const & test)
+      {
+      return test_invoke<typename templ_list::type_iterator>::do_run(test);
+      }
+
+    template<typename unit_test>
+    consteval static test_result consteval_run(unit_test const & test)
+      {
+      return test_invoke<typename templ_list::type_iterator>::do_run(test);
+      }
+
+    template<typename unit_test>
+    constexpr static test_result do_run(unit_test const & test)
+      {
+      using test_type = typename templ_list::type;
+      using next_test = typename templ_list::next_elem;
+      using ptr_type = test_type const *;
+      test_result res = test(ptr_type{});
+      if constexpr(!std::is_same_v<void, next_test>)
+        res |= test_invoke<next_test>::do_run(test);
+      return res;
+      }
+    };
+
+  }  // namespace detail
+
+template<typename templ_list, typename unit_test>
+[[maybe_unused]]
+constexpr test_result
+  run_constexpr_test(unit_test const & test, source_location const location = source_location::current())
+  {
+  return constexpr_test(detail::test_invoke<templ_list>::constexpr_run(test), location);
+  }
+
+template<typename templ_list, typename unit_test>
+[[maybe_unused]]
+consteval test_result
+  run_consteval_test(unit_test const & test, source_location const location = source_location::current())
+  {
+#ifndef DISABLE_CONSTEVAL_TESTING
+  // same gcc can fail building consteval complicated code, ex on ubuntu it reports nonsense while on gentoo there is no
+  // problem at all
+  return constexpr_test(detail::test_invoke<templ_list>::consteval_run(test), location);
+#else
+  return test_result{};
+#endif
+  }
+
+consteval test_result test()
+  {
+  using traits_test_list = metatests::type_list<uint16_t, int32_t, int64_t, double>;
+  int counter{};
+  auto test_fn = [&counter]<typename value_type>(value_type const *) -> test_result
+  {
+    counter++;
+    return test_result{};
+  };
+
+  auto res = run_constexpr_test<traits_test_list>(test_fn);
+  return res | test_result{counter == 4};
+  }
+
+static_assert(test());
+
+namespace detail
+  {
+  template<typename templ_list, typename templ_list2>
+  struct test_invoke_dual
+    {
+    template<typename unit_test>
+    constexpr static test_result constexpr_run(unit_test const & test)
+      {
+      return test_invoke_dual<typename templ_list::type_iterator, typename templ_list2::type_iterator>::do_run(test);
+      }
+
+    template<typename unit_test>
+    consteval static test_result consteval_run(unit_test const & test)
+      {
+      return test_invoke_dual<typename templ_list::type_iterator, typename templ_list2::type_iterator>::do_run(test);
+      }
+
+    template<typename unit_test>
+    constexpr static test_result do_run(unit_test const & test)
+      {
+      using test_type = typename templ_list::type;
+      using next_test = typename templ_list::next_elem;
+
+      test_result res = do_run_sec<test_type>(test);
+      if constexpr(!std::is_same_v<void, next_test>)
+        res |= test_invoke_dual<next_test, templ_list2>::do_run(test);
+      return res;
+      }
+
+    template<typename test_type1, typename unit_test>
+    constexpr static test_result do_run_sec(unit_test const & test)
+      {
+      using test_type2 = typename templ_list2::type;
+      using next_test = typename templ_list2::next_elem;
+
+      using ptr_type1 = test_type1 const *;
+      using ptr_type2 = test_type2 const *;
+      test_result res = test(ptr_type1{}, ptr_type2{});
+      if constexpr(!std::is_same_v<void, next_test>)
+        res |= test_invoke_dual<templ_list, next_test>::template do_run_sec<test_type1>(test);
+      return res;
+      }
+    };
+  }  // namespace detail
+
+template<typename templ_list, typename templ_list2, typename unit_test>
+[[maybe_unused]]
+constexpr test_result
+  run_constexpr_test_dual(unit_test const & test, source_location const location = source_location::current())
+  {
+  return constexpr_test(detail::test_invoke_dual<templ_list, templ_list2>::constexpr_run(test), location);
+  }
+
+template<typename templ_list, typename templ_list2, typename unit_test>
+[[maybe_unused]]
+consteval test_result
+  run_consteval_test_dual(unit_test const & test, source_location const location = source_location::current())
+  {
+#ifndef DISABLE_CONSTEVAL_TESTING
+  // same gcc can fail building consteval complicated code, ex on ubuntu it reports nonsense while on gentoo there is no
+  // problem at all
+  return constexpr_test(detail::test_invoke_dual<templ_list, templ_list2>::consteval_run(test), location);
+#else
+  return test_result{};
+#endif
+  }
+
+consteval test_result test_dual()
+  {
+  using traits_test_list = metatests::type_list<uint16_t, int32_t, int64_t, double>;
+  using traits_test_list2 = metatests::type_list<uint16_t, uint32_t, uint64_t>;
+  int counter{};
+  auto test_fn
+    = [&counter]<typename value_type, typename value_type2>(value_type const *, value_type2 const *) -> test_result
+  {
+    counter++;
+    return test_result{};
+  };
+
+  auto res = run_constexpr_test_dual<traits_test_list, traits_test_list2>(test_fn);
+  return res | test_result{counter == 12};
+  }
+
+static_assert(test_dual());
+  }  // namespace metatests
+
+void dump(auto const & result)
+  {
+  for(auto el: result)
+    std::cout << el << ",";
+  std::cout << std::endl;
+  }
+
+struct non_trivial
+  {
+  int value_;
+
+  constexpr non_trivial() noexcept : value_{0x1fff'ffff} {}
+
+  constexpr non_trivial(int value) noexcept : value_{value} {}
+
+  constexpr non_trivial(non_trivial && r) noexcept : value_{std::exchange(r.value_, 0x1fff'ffff)} {}
+
+  constexpr non_trivial(non_trivial const & r) noexcept : value_{r.value_} {}
+
+  constexpr non_trivial & operator=(non_trivial && r) noexcept
+    {
+    value_ = std::exchange(r.value_, 0x1fff'ffff);
+    return *this;
+    }
+
+  constexpr non_trivial & operator=(non_trivial const & r) noexcept
+    {
+    value_ = r.value_;
+    return *this;
+    }
+
+  constexpr non_trivial & operator++() noexcept
+    {
+    ++value_;
+    return *this;
+    }
+
+  constexpr ~non_trivial() {}
+
+  constexpr bool operator==(non_trivial const & r) const noexcept = default;
+
+  constexpr bool operator==(int r) const noexcept { return value_ == r; }
+
+  void swap(non_trivial & r) noexcept { std::swap(value_, r.value_); }
+  };
+
+inline std::ostream & operator<<(std::ostream & stream, non_trivial const & v)
+  {
+  stream << v.value_;
+  return stream;
+  }
+
+struct non_trivial_ptr
+  {
+  int * value_;
+
+  constexpr non_trivial_ptr() noexcept : value_{} {}
+
+  constexpr non_trivial_ptr(int value) noexcept : value_{new int{value}} {}
+
+  constexpr non_trivial_ptr(non_trivial_ptr && r) noexcept : value_{std::exchange(r.value_, nullptr)} {}
+
+  constexpr non_trivial_ptr(non_trivial_ptr const & r) noexcept : value_{}
+    {
+    if(r.value_ != nullptr)
+      value_ = new int(*r.value_);
+    }
+
+  constexpr non_trivial_ptr & operator=(non_trivial_ptr && r) noexcept
+    {
+    if(value_ != nullptr)
+      delete value_;
+
+    value_ = std::exchange(r.value_, nullptr);
+    return *this;
+    }
+
+  constexpr non_trivial_ptr & operator=(non_trivial_ptr const & r) noexcept
+    {
+    if(value_ != nullptr)
+      {
+      delete value_;
+      value_ = nullptr;
+      }
+    if(r.value_ != nullptr)
+      value_ = new int(*r.value_);
+    return *this;
+    }
+
+  constexpr non_trivial_ptr & operator++() noexcept
+    {
+    assert(value_ != nullptr);
+    ++*value_;
+    return *this;
+    }
+
+  constexpr ~non_trivial_ptr()
+    {
+    if(value_ != nullptr)
+      delete value_;
+    }
+
+  constexpr bool operator==(non_trivial_ptr const & r) const noexcept
+    {
+    if(value_ != nullptr && r.value_ != nullptr)
+      return *value_ == *r.value_;
+
+    return value_ == nullptr && r.value_ == nullptr;
+    }
+
+  constexpr bool operator==(int r) const noexcept
+    {
+    if(value_ != nullptr)
+      return *value_ == r;
+    return false;
+    }
+
+  constexpr int value() const noexcept { return *value_; }
+
+  constexpr void swap(non_trivial_ptr & r) noexcept { std::swap(value_, r.value_); }
+  };
+
+struct non_trivial_ptr_except
+  {
+  non_trivial_ptr obj;
+  constexpr non_trivial_ptr_except() noexcept(false) = default;
+
+  constexpr non_trivial_ptr_except(int value) noexcept(false) : obj{value} {}
+
+  constexpr non_trivial_ptr_except(non_trivial_ptr_except && r) noexcept(false) = default;
+  constexpr non_trivial_ptr_except(non_trivial_ptr_except const & r) noexcept(false) = default;
+  constexpr non_trivial_ptr_except & operator=(non_trivial_ptr_except && r) noexcept(false) = default;
+  constexpr non_trivial_ptr_except & operator=(non_trivial_ptr_except const & r) noexcept(false) = default;
+  constexpr ~non_trivial_ptr_except() = default;
+
+  constexpr non_trivial_ptr_except & operator++() noexcept
+    {
+    ++obj;
+    return *this;
+    }
+
+  constexpr bool operator==(non_trivial_ptr_except const &) const noexcept = default;
+
+  constexpr int value() const noexcept(false) { return obj.value(); }
+
+  constexpr void swap(non_trivial_ptr_except & r) { std::swap(obj, r.obj); }
+  };
+
+struct non_trivial_ptr_except_copy
+  {
+  non_trivial_ptr obj;
+  constexpr non_trivial_ptr_except_copy() noexcept(false) = default;
+
+  constexpr non_trivial_ptr_except_copy(int value) noexcept(false) : obj{value} {}
+
+  constexpr non_trivial_ptr_except_copy(non_trivial_ptr_except_copy const & r) noexcept(false) = default;
+  constexpr non_trivial_ptr_except_copy & operator=(non_trivial_ptr_except_copy const & r) noexcept(false) = default;
+  constexpr ~non_trivial_ptr_except_copy() = default;
+
+  constexpr non_trivial_ptr_except_copy & operator++() noexcept
+    {
+    ++obj;
+    return *this;
+    }
+
+  constexpr bool operator==(non_trivial_ptr_except_copy const &) const noexcept = default;
+  };
+
+// for testing strong exception guarantee
+template<typename Super, int throw_at_value>
+struct non_trivial_throwing_tmpl : public Super
+  {
+  using super_type = Super;
+  constexpr non_trivial_throwing_tmpl() noexcept(std::is_nothrow_default_constructible_v<super_type>) = default;
+
+  constexpr non_trivial_throwing_tmpl(int value) noexcept(std::is_nothrow_constructible_v<super_type, int>) :
+      super_type{value}
+    {
+    }
+
+  constexpr non_trivial_throwing_tmpl(non_trivial_throwing_tmpl const & r) : super_type{r}
+    {
+    if constexpr(not noexcept(super_type{r}))
+      if(operator==(throw_at_value))
+        throw std::runtime_error{""};
+    }
+
+  constexpr non_trivial_throwing_tmpl(non_trivial_throwing_tmpl && r) noexcept(noexcept(super_type{std::move(r)})) :
+      super_type{std::move(r)}
+    {
+    if constexpr(not noexcept(super_type{std::move(r)}))
+      if(operator==(throw_at_value))
+        throw std::runtime_error{""};
+    }
+
+  using super_type::operator==;
+  using super_type::operator++;
+
+  void set_value(int value) { super_type::operator=(value); }
+
+  constexpr non_trivial_throwing_tmpl & operator=(non_trivial_throwing_tmpl const & r)
+    {
+    super_type::operator=(r);
+    if constexpr(not noexcept(super_type::operator=(r)))
+      if(operator==(throw_at_value))
+        throw std::runtime_error{""};
+    return *this;
+    }
+
+  constexpr non_trivial_throwing_tmpl & operator=(non_trivial_throwing_tmpl && r
+  ) noexcept(noexcept(super_type::operator=(std::move(r))))
+    {
+    super_type::operator=(r);
+    if constexpr(not noexcept(super_type::operator=(std::move(r))))
+      if(operator==(throw_at_value))
+        throw std::runtime_error{""};
+    return *this;
+    }
+
+  constexpr ~non_trivial_throwing_tmpl() = default;
+  };
+
+template<int throw_at_value>
+using non_trivial_throwing = non_trivial_throwing_tmpl<non_trivial_ptr_except, throw_at_value>;
+
+template<int throw_at_value>
+using non_trivial_throwing_copy = non_trivial_throwing_tmpl<non_trivial_ptr_except_copy, throw_at_value>;
+
+std::ostream & operator<<(std::ostream & stream, non_trivial_ptr const & v);
+std::ostream & operator<<(std::ostream & stream, non_trivial_ptr_except const & v);
+std::ostream & operator<<(std::ostream & stream, non_trivial_ptr_except_copy const & v);

--- a/unittests/utf_.cc
+++ b/unittests/utf_.cc
@@ -458,5 +458,59 @@ int main()
     result |= run_constexpr_test(fn_tmpl);
     result |= run_consteval_test(fn_tmpl);
   };
+  "utf_explicit_output_iterator_t<char>"_test = [&]
+  {
+    auto fn_tmpl = []() -> metatests::test_result
+    {
+      if(!std::is_constant_evaluated() || enable_consteval_string_testing)
+        {
+        utf::utf_input_view_t input{u16test};
+        std::vector<char8_t> output;
+        utf::utf_explicit_output_iterator_t<char8_t>::iterator oit{std::back_inserter(output)};
+        std::ranges::copy(input, oit);
+
+        constexpr_test(std::u8string_view{output.data(), output.size()} == u8test);
+        }
+      return {};
+    };
+    result |= run_constexpr_test(fn_tmpl);
+    result |= run_consteval_test(fn_tmpl);
+  };
+  "utf_explicit_output_iterator_t<char16>"_test = [&]
+  {
+    auto fn_tmpl = []() -> metatests::test_result
+    {
+      if(!std::is_constant_evaluated() || enable_consteval_string_testing)
+        {
+        utf::utf_input_view_t input{u8test};
+        std::vector<char16_t> output;
+        utf::utf_explicit_output_iterator_t<char16_t>::iterator oit{std::back_inserter(output)};
+        std::ranges::copy(input, oit);
+
+        constexpr_test(std::u16string_view{output.data(), output.size()} == u16test);
+        }
+      return {};
+    };
+    result |= run_constexpr_test(fn_tmpl);
+    result |= run_consteval_test(fn_tmpl);
+  };
+  "utf_explicit_output_iterator_t<char32>"_test = [&]
+  {
+    auto fn_tmpl = []() -> metatests::test_result
+    {
+      if(!std::is_constant_evaluated() || enable_consteval_string_testing)
+        {
+        utf::utf_input_view_t input{u8test};
+        std::vector<char32_t> output;
+        utf::utf_explicit_output_iterator_t<char32_t>::iterator oit{std::back_inserter(output)};
+        std::ranges::copy(input, oit);
+
+        constexpr_test(std::u32string_view{output.data(), output.size()} == u32test);
+        }
+      return {};
+    };
+    result |= run_constexpr_test(fn_tmpl);
+    result |= run_consteval_test(fn_tmpl);
+  };
   }
 


### PR DESCRIPTION
- adding utf_explicit_output_iterator_t - for use with untyped output iterator like std::back_inserter
- add presets for clang-18 and gcc-14
- update test workflow